### PR TITLE
Another one :)

### DIFF
--- a/feedback/templates/feedback/feedback_form.html
+++ b/feedback/templates/feedback/feedback_form.html
@@ -4,7 +4,7 @@
     <form action="" method="post">
         {% csrf_token %}
         <table>
-            {{ form.as_table }}
+            {{ feedback_form.as_table }}
             <tr>
                 <td colspan='2'>
                     <input type="submit" value="Leave feedback" />

--- a/feedback/views.py
+++ b/feedback/views.py
@@ -14,5 +14,5 @@ def leave_feedback(request, template_name='feedback/feedback_form.html'):
         feedback.save()
         request.user.message_set.create(message=_("Your feedback has been saved successfully."))
         return HttpResponseRedirect(request.POST.get('next', request.META.get('HTTP_REFERER', '/')))
-    return render_to_response(template_name, {'form': form}, context_instance=RequestContext(request))
+    return render_to_response(template_name, {'feedback_form': form}, context_instance=RequestContext(request))
 


### PR DESCRIPTION
Thanks for pulling!

I noticed that using your view, and of course the context processors, an invalid form loses the errors.

This is apparently because Django gets confused about feedback_form and form, so I renamed that and it seems to work fine now.
