### PR TITLE
Bugfix: Add AnonymousFeedbackAdmin

### DIFF
--- a/feedback/admin.py
+++ b/feedback/admin.py
@@ -3,7 +3,8 @@ from django.conf.urls import patterns, url
 from django.contrib import admin
 from django.shortcuts import get_object_or_404, render_to_response
 from django.template import RequestContext
-from feedback.models import AnonymousFeedback, Feedback
+
+from .models import AnonymousFeedback, Feedback
 
 
 class FeedbackAdmin(admin.ModelAdmin):
@@ -32,7 +33,33 @@ class FeedbackAdmin(admin.ModelAdmin):
                                   context_instance=RequestContext(request))
 
 
+class AnonymousFeedbackAdmin(admin.ModelAdmin):
+    list_display = ['user', 'message', 'time', 'type', 'view']
+    search_fields = ['user', 'message']
+    list_filter = ['type', 'time']
+
+    def view(self, obj):
+        return "<a href='%s'>View</a>" % obj.get_absolute_url()
+
+    view.allow_tags = True
+
+    def get_urls(self):
+        urls = super(AnonymousFeedbackAdmin, self).get_urls()
+        my_urls = patterns('',
+            url(r'^view/(?P<feedback_id>\d+)/$',
+                self.admin_site.admin_view(self.view_feedback),
+                name='view-anon-feedback'),
+        )
+        return my_urls + urls
+
+    def view_feedback(self, request, feedback_id):
+        feedback = get_object_or_404(AnonymousFeedback, id=feedback_id)
+        context = {'feedback': feedback}
+        return render_to_response('feedback/view_feedback.html', context,
+                                  context_instance=RequestContext(request))
+
+
 admin.site.register(Feedback, FeedbackAdmin)
 if getattr(settings, 'ALLOW_ANONYMOUS_FEEDBACK', False):
-    admin.site.register(AnonymousFeedback, FeedbackAdmin)
+    admin.site.register(AnonymousFeedback, AnonymousFeedbackAdmin)
 admin.site.index_template = 'feedback/index.html'

--- a/feedback/models.py
+++ b/feedback/models.py
@@ -18,14 +18,17 @@ class BaseFeedback(models.Model):
     def __unicode__(self):
         return self.message
 
-    def get_absolute_url(self):
-        return reverse('admin:view-feedback', args=[self.id])
-
 
 class Feedback(BaseFeedback):
     user = models.ForeignKey(User, verbose_name=_('User'))
+
+    def get_absolute_url(self):
+        return reverse('admin:view-feedback', args=[self.id])
 
 
 class AnonymousFeedback(BaseFeedback):
     user = models.ForeignKey(User, verbose_name=_('User'), null=True,
                              blank=True, default=None)
+
+    def get_absolute_url(self):
+        return reverse('admin:view-anon-feedback', args=[self.id])


### PR DESCRIPTION
Hey,

In the last pull request I didn't fix the problem of showing anonymous feedback correctly. I added anonymous feedback links, but they don't show the correct feedback (they show authenticated feedback instead of anonymous feedback). This occurred because I was registering the FeedbackAdmin, which didn't implement any functionality to show anonymous feedback.

I added a new AnonymousFeedbackAdmin and now it (really!) works.
