### PR TITLE
Add dependency information for `django.contrib.sites`.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,6 +8,8 @@ from authenticated users within your Django project.
 Installation
 ============
 
+Make sure that ``django.contrib.sites`` is listed in your ``INSTALLED_APPS``.
+
 Put ``feedback`` in your ``INSTALLED_APPS``, and set ``FEEDBACK_CHOICES`` to a 2-tuple of feedback types
 in your settings file. For example::
 


### PR DESCRIPTION
Add dependency information for `django.contrib.sites` in README.rst.
